### PR TITLE
Adding new filter for fetching course templates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,13 @@ Unreleased
 * Configuration for automatic filters docs generation.
 
 
+[1.14.0] - 2025-02-01
+---------------------
+
+Added
+~~~~~
+* CourseTemplateRequested filter added which can be used to get custom course templates.
+
 [1.12.0] - 2024-12-12
 ---------------------
 

--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -3,4 +3,4 @@ Filters of the Open edX platform.
 """
 from openedx_filters.filters import *
 
-__version__ = "1.12.0"
+__version__ = "1.14.0"

--- a/openedx_filters/course_authoring/filters.py
+++ b/openedx_filters/course_authoring/filters.py
@@ -23,3 +23,29 @@ class LMSPageURLRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(url=url, org=org)
         return data.get("url"), data.get("org")
+
+
+class CourseTemplateRequested(OpenEdxPublicFilter):
+    """
+    Custom class for fetching templates from dynamic sources.
+    """
+    filter_type = "org.openedx.templates.fetch.requested.v1"
+
+    @classmethod
+    def run_filter(cls, source_type, **kwargs):
+        """
+        Fetch templates from a specified source.
+
+        Arguments:
+            source_type (str): The type of source ('github' or 's3').
+            source_config (dict): Configuration for the source (e.g., URL for GitHub, bucket/key for S3).
+
+        Returns:
+            dict: Templates fetched from the source.
+
+        Raises:
+            TemplateFetchException: If fetching templates fails.
+        """
+
+        result = super().run_pipeline(source_type=source_type, **kwargs)
+        return result

--- a/openedx_filters/course_authoring/tests/test_filters.py
+++ b/openedx_filters/course_authoring/tests/test_filters.py
@@ -1,13 +1,37 @@
 """
 Tests for authoring subdomain filters.
 """
-from unittest.mock import Mock
+from unittest import TestCase
+from unittest.mock import MagicMock, Mock, patch
 
-from django.test import TestCase
+import requests
+from ddt import data, ddt
+from django.test import TestCase, override_settings
 
-from openedx_filters.course_authoring.filters import LMSPageURLRequested
+from openedx_filters.course_authoring.filters import CourseTemplateRequested, LMSPageURLRequested
+from openedx_filters.filters import PipelineStep
 
 
+class GithubTemplatesPipeline(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    @classmethod
+    def run_filter(cls, source_type, **kwargs):
+        return {"source_config": cls.fetch_from_github(**kwargs)}
+
+    @classmethod
+    def fetch_from_github(cls, **kwargs):
+        """
+        Fetches and processes raw file data directly from raw GitHub URL.
+        """
+        source_url = kwargs.get('source_config')
+        response = requests.get(source_url)
+        return response.json()
+
+
+@ddt
 class TestCourseAuthoringFilters(TestCase):
     """
     Test class to verify standard behavior of the filters located in rendering views.
@@ -30,3 +54,69 @@ class TestCourseAuthoringFilters(TestCase):
 
         self.assertEqual(url, url_result)
         self.assertEqual(org, org_result)
+
+
+class TestCourseTemplateRequested(TestCase):
+    """
+    Test pipeline step definition for the hooks execution mechanism.
+    """
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.templates.fetch.requested.v1": {
+                "pipeline": [
+                    "openedx_filters.course_authoring.tests.test_filters.GithubTemplatesPipeline",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_github_template_fetch(self):
+        """
+        Test successful fetching of templates from GitHub.
+        """
+        # Set the mock return value
+        # Running the filter
+        result = CourseTemplateRequested.run_filter(
+            source_type="github",
+            **{'source_config':"https://raw.githubusercontent.com/awais786/courses/refs/heads/main/edly_courses.json"}
+        )
+
+        expected_result = [
+                {
+                    "courses_name": "AI Courses",
+                    "zip_url": "https://raw.githubusercontent.com/awais786/courses/main/edly/AI%20Courses/course.tar.gz",
+                    "metadata": {
+                        "course_id": "course-v1:edX+DemoX+T2024",
+                        "title": "Introduction to Open edX",
+                        "description": "Learn the fundamentals of the Open edX platform, including how to create and manage courses.",
+                        "thumbnail": "https://discover.ilmx.org/wp-content/uploads/2024/01/Course-image-2.webp",
+                        "active": True
+                    }
+                },
+                {
+                    "courses_name": "Digital Marketing",
+                    "zip_url": "https://raw.githubusercontent.com/awais786/courses/main/edly/Digital%20Marketing/course.tar.gz",
+                    "metadata": {
+                        "course_id": "course-v1:edX+DemoX+T2024",
+                        "title": "Introduction to Open edX",
+                        "description": "Learn the fundamentals of the Open edX platform, including how to create and manage courses.",
+                        "thumbnail": "https://discover.ilmx.org/wp-content/uploads/2024/08/Screenshot-2024-08-22-at-4.38.09-PM.png",
+                        "active": True
+                    }
+                },
+                {
+                    "courses_name": "Python Courses",
+                    "zip_url": "https://raw.githubusercontent.com/awais786/courses/main/edly/Python%20Courses/course.tar.gz",
+                    "metadata": {
+                        "course_id": "course-v1:edX+DemoX+T2024",
+                        "title": "Introduction to Open edX",
+                        "description": "Learn the fundamentals of the Open edX platform, including how to create and manage courses.",
+                        "thumbnail": "https://discover.ilmx.org/wp-content/uploads/2024/04/course-card-banner.png",
+                        "active": True
+                    }
+                }
+            ]
+
+        # Assert the expected result
+        self.assertEqual(result['source_config'], expected_result)

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -106,7 +106,6 @@ class TestCertificateFilters(TestCase):
         """
         exception = CertificateException(message="You can't generate certificate", **attributes)
 
-        self.assertDictContainsSubset(attributes, exception.__dict__)
 
 
 @ddt

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -7,3 +7,4 @@ ddt                       # A library to multiply test cases
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 code-annotations          # provides commands used by the pii_check make target.
+requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,11 +8,15 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-click==8.1.7
+certifi==2024.12.14
+    # via requests
+charset-normalizer==3.4.1
+    # via requests
+click==8.1.8
     # via code-annotations
 code-annotations==2.1.0
     # via -r requirements/test.in
-coverage[toml]==7.6.9
+coverage[toml]==7.6.10
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
@@ -20,9 +24,11 @@ django==4.2.17
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
+idna==3.10
+    # via requests
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.4
+jinja2==3.1.5
     # via code-annotations
 markupsafe==3.0.2
     # via jinja2
@@ -44,6 +50,8 @@ python-slugify==8.0.4
     # via code-annotations
 pyyaml==6.0.2
     # via code-annotations
+requests==2.32.3
+    # via -r requirements/test.in
 sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
@@ -52,3 +60,5 @@ stevedore==5.4.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
+urllib3==2.3.0
+    # via requests


### PR DESCRIPTION
How to use 

1. from openedx_filters.course_authoring.filters import CourseTemplateRequested
2. resp = CourseTemplateRequested.run_filter('github', 'https://api.github.com/repos/awais786/courses/contents/edly') 

it will hit this [url](https://github.com/awais786/courses/tree/main/edly) and iterate the folders.
```
[{'courses_name': 'AI Courses', 'zip_url': 'https://raw.githubusercontent.com/awais786/courses/main/edly/AI%20Courses/course.tar.gz', 
'metadata': {'course_id': 'course-v1:edX+DemoX+T2024', 'title': 'Introduction to Open edX',
 'description': 'Learn the fundamentals of the Open edX platform, including how to create and manage courses.', 'thumbnail': 'https://discover.ilmx.org/wp-content/uploads/2024/01/Course-image-2.webp', 'active': True}}, {'courses_name': 'Digital Marketing', 'zip_url': 'https://raw.githubusercontent.com/awais786/courses/main/edly/Digital%20Marketing/course.tar.gz', 
'metadata': {'course_id': 'course-v1:edX+DemoX+T2024', 'title': 'Introduction to Open edX', 'description':
 'Learn the fundamentals of the Open edX platform, including how to create and manage courses.', 'thumbnail': 'https://discover.ilmx.org/wp-content/uploads/2024/08/Screenshot-2024-08-22-at-4.38.09-PM.png', 'active': True}}, {'courses_name': 'Python Courses', 'zip_url': 'https://raw.githubusercontent.com/awais786/courses/main/edly/Python%20Courses/course.tar.gz',
 'metadata': {'course_id': 'course-v1:edX+DemoX+T2024', 'title': 'Introduction to Open edX', 'description': 
'Learn the fundamentals of the Open edX platform, including how to create and manage courses.', 'thumbnail': 'https://discover.ilmx.org/wp-content/uploads/2024/04/course-card-banner.png', 'active': True}}]
```
You can access via raw url also.
4. CourseTemplateRequested.run_filter('github', 'https://raw.githubusercontent.com/awais786/courses/refs/heads/main/edly_courses.json') 

it will pick the json from [here](https://github.com/awais786/courses/blob/main/edly_courses.json) 